### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ cp .env.example .env  # edit variables
 python run.py
 ```
 
+### One-click install
+
+Simply run the provided script to set up everything at once:
+
+```bash
+./install.sh
+```
+
 ### Docker
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# One-click installation script for Crypto Price Alert Bot
+# This script sets up a Python virtual environment, installs dependencies,
+# and prepares the .env configuration file.
+
+set -e
+
+# Determine project root (directory of this script)
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+# Check for Python 3
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 is required but not found. Please install Python 3." >&2
+    exit 1
+fi
+
+# Create virtual environment if not present
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+# Activate virtual environment
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+# Upgrade pip and install requirements
+pip install --upgrade pip
+pip install -r requirements.txt
+
+deactivate
+
+# Create .env from example if not present
+if [ ! -f ".env" ]; then
+    cp .env.example .env
+    echo "Created .env. Please edit it with your configuration." 
+fi
+
+cat <<INFO
+Installation complete.
+To start the bot:
+  source venv/bin/activate && python run.py
+INFO


### PR DESCRIPTION
## Summary
- add `install.sh` for one-click setup
- document how to use the new script in the README

## Testing
- `python -m py_compile bot/__init__.py bot/config.py bot/db.py bot/handlers/__init__.py bot/handlers/commands.py bot/price.py bot/scheduler.py run.py`
- `shellcheck install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874c2c04a0c8321aa4ce89222fce41d