### PR TITLE
Fix Python 3.9 compatibility issue

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,7 +1,8 @@
 import os
 from dotenv import load_dotenv
+from typing import Optional
 
 
-def load_env(path: str | None = None) -> None:
+def load_env(path: Optional[str] = None) -> None:
     load_dotenv(dotenv_path=path)
     os.environ.setdefault("DB_PATH", "./crypto.db")


### PR DESCRIPTION
## Summary
- update `load_env` signature to use Optional
- add missing import for Optional in `bot/config.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: BOT_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_6874c61eb7308321899077ddc2fc17c5