### PR TITLE
Add yum fallback for Python install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Minimal async Telegram bot notifying when a coin hits a target price.
 
 ## Quickstart
 
+Ensure you have **Python 3.8 or newer** available:
+
 ```bash
-python -m venv venv
+python3 --version
+```
+
+```bash
+python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env  # edit variables
@@ -14,7 +20,9 @@ python run.py
 
 ### One-click install
 
-Simply run the provided script to set up everything at once:
+Simply run the provided script to set up everything at once. If Python 3.8+
+is not available, the script will attempt to install it via `apt`, `yum` or
+`dnf` (requires sudo privileges):
 
 ```bash
 ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -9,15 +9,42 @@ set -e
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
-# Check for Python 3
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Python 3 is required but not found. Please install Python 3." >&2
+# Check for Python 3.8+
+PYTHON=${PYTHON:-python3}
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "Python 3.8+ not found. Installing python3.8..."
+        sudo apt-get update
+        sudo apt-get install -y python3.8 python3.8-venv
+        PYTHON=python3.8
+    elif command -v yum >/dev/null 2>&1; then
+        echo "Python 3.8+ not found. Installing python3 via yum..."
+        sudo yum install -y python3
+        PYTHON=python3
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "Python 3.8+ not found. Installing python3 via dnf..."
+        sudo dnf install -y python3
+        PYTHON=python3
+    else
+        echo "Python 3.8+ is required but automatic installation failed." >&2
+        echo "Please install Python 3.8 or newer and re-run this script." >&2
+        exit 1
+    fi
+fi
+
+# Verify that the Python version meets the minimum requirement
+if ! "$PYTHON" - <<'EOF'
+import sys
+sys.exit(0 if sys.version_info >= (3, 8) else 1)
+EOF
+then
+    echo "Python 3.8 or higher is required. Current version: $($PYTHON --version)" >&2
     exit 1
 fi
 
 # Create virtual environment if not present
 if [ ! -d "venv" ]; then
-    python3 -m venv venv
+    "$PYTHON" -m venv venv
 fi
 
 # Activate virtual environment


### PR DESCRIPTION
## Summary
- auto-install Python with apt, yum or dnf
- clarify supported package managers in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6874c81bf1f88321b75b546f9f1f70af