### PR TITLE
Fix event loop conflict in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,23 +1,31 @@
 import asyncio
 import os
+
+from telegram.ext import ApplicationBuilder
+
 from bot.config import load_env
 from bot.handlers import register_handlers
 from bot.scheduler import setup_scheduler
 from bot.db import init_db
-from telegram.ext import ApplicationBuilder
 
 
-async def main() -> None:
+def main() -> None:
+    """Start the Telegram bot."""
+
     load_env()
     token = os.getenv("BOT_TOKEN")
     if not token:
         raise RuntimeError("BOT_TOKEN not set")
-    await init_db()
+
+    # initialize database in its own event loop
+    asyncio.run(init_db())
+
     app = ApplicationBuilder().token(token).build()
     register_handlers(app)
     setup_scheduler(app)
-    await app.run_polling()
+
+    app.run_polling()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- initialize database before starting the Application
- call `Application.run_polling()` directly instead of awaiting it

## Testing
- `python -m py_compile run.py bot/*.py bot/handlers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6874d9766ce08321b33f31e93fb28138