### PR TITLE
Fix scheduler start with Telegram Application

### DIFF
--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -17,4 +17,8 @@ async def check_prices(app: Application) -> None:
 
 def setup_scheduler(app: Application) -> None:
     scheduler.add_job(check_prices, "interval", minutes=1, args=(app,))
-    scheduler.start()
+
+    async def start(_: Application) -> None:
+        scheduler.start()
+
+    app.post_init = start

--- a/run.py
+++ b/run.py
@@ -24,6 +24,9 @@ def main() -> None:
     register_handlers(app)
     setup_scheduler(app)
 
+    # create event loop for Application
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     app.run_polling()
 
 


### PR DESCRIPTION
## Summary
- start APScheduler when the Telegram event loop has initialized
- prepare event loop before calling `run_polling`

## Testing
- `python -m py_compile run.py bot/*.py bot/handlers/*.py`
- `BOT_TOKEN=dummy python run.py` *(fails: httpx.ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6874df32395c83219ce8aeb1ec366d90