### PR TITLE
Add subscription-based crypto alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Crypto Price Alert Bot
 
-Simple Telegram bot that sends the current Bitcoin price every minute after the
-`/start` command.
+Telegram bot that sends price alerts for your favourite cryptocurrency.
+Users can subscribe to coins and receive a message when the price changes more
+than a chosen percentage.
 
 ## Quickstart
 
@@ -19,8 +20,15 @@ cp .env.example .env  # edit variables
 python run.py
 ```
 
-Once the bot is running, send `/start` in a chat with your bot to receive the
-current Bitcoin price every minute.
+Start the bot and use `/start` in a chat with your bot. You can then subscribe
+to coin alerts with:
+
+```bash
+/subscribe <coin> [percent]
+```
+
+List active subscriptions with `/list` and remove them using
+`/unsubscribe <coin>`.
 
 ### One-click install
 

--- a/run.py
+++ b/run.py
@@ -1,65 +1,220 @@
 import os
+from typing import Optional, Dict, Tuple
 
-from dotenv import load_dotenv
 import aiohttp
-from telegram import Update
+import aiosqlite
+from dotenv import load_dotenv
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import (
     ApplicationBuilder,
+    CallbackQueryHandler,
     CommandHandler,
     ContextTypes,
 )
 
+DB_FILE = "subs.db"
+DEFAULT_THRESHOLD = 3.0
 
-async def get_bitcoin_price() -> float:
-    """Fetch the current Bitcoin price in USD."""
+
+async def init_db() -> None:
+    """Ensure the subscriptions table exists."""
+    async with aiosqlite.connect(DB_FILE) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS subscriptions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id INTEGER NOT NULL,
+                coin_id TEXT NOT NULL,
+                threshold REAL NOT NULL,
+                last_price REAL
+            )
+            """
+        )
+        await db.commit()
+
+
+async def get_price(coin: str) -> Optional[float]:
+    """Return the current USD price for a coin from CoinGecko."""
     url = (
         "https://api.coingecko.com/api/v3/simple/price"
-        "?ids=bitcoin&vs_currencies=usd"
+        f"?ids={coin}&vs_currencies=usd"
     )
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
+            if resp.status != 200:
+                return None
             data = await resp.json()
-            return float(data["bitcoin"]["usd"])
+            if coin not in data:
+                return None
+            return float(data[coin]["usd"])
 
 
-async def send_price(context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Send the current Bitcoin price to the chat."""
-    price = await get_bitcoin_price()
-    await context.bot.send_message(
-        chat_id=context.job.chat_id,
-        text=f"Bitcoin price: ${price}",
-    )
+async def subscribe_coin(chat_id: int, coin: str, threshold: float) -> None:
+    async with aiosqlite.connect(DB_FILE) as db:
+        await db.execute(
+            """
+            INSERT INTO subscriptions (chat_id, coin_id, threshold)
+            VALUES (?, ?, ?)
+            """,
+            (chat_id, coin, threshold),
+        )
+        await db.commit()
+
+
+async def unsubscribe_coin(chat_id: int, coin: str) -> None:
+    async with aiosqlite.connect(DB_FILE) as db:
+        await db.execute(
+            "DELETE FROM subscriptions WHERE chat_id=? AND coin_id=?",
+            (chat_id, coin),
+        )
+        await db.commit()
+
+
+async def list_subscriptions(chat_id: int) -> list[Tuple[str, float]]:
+    async with aiosqlite.connect(DB_FILE) as db:
+        cursor = await db.execute(
+            "SELECT coin_id, threshold FROM subscriptions WHERE chat_id=?",
+            (chat_id,),
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        return [(row[0], row[1]) for row in rows]
+
+
+async def set_last_price(sub_id: int, price: float) -> None:
+    async with aiosqlite.connect(DB_FILE) as db:
+        await db.execute(
+            "UPDATE subscriptions SET last_price=? WHERE id=?",
+            (price, sub_id),
+        )
+        await db.commit()
+
+
+async def check_prices(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Periodic job that checks prices and notifies users."""
+    async with aiosqlite.connect(DB_FILE) as db:
+        cursor = await db.execute(
+            "SELECT id, chat_id, coin_id, threshold, last_price FROM subscriptions"
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+
+    # Group subscriptions by coin to minimize API calls
+    by_coin: Dict[str, list[Tuple[int, int, float, Optional[float]]]] = {}
+    for sub_id, chat_id, coin, threshold, last_price in rows:
+        by_coin.setdefault(coin, []).append((sub_id, chat_id, threshold, last_price))
+
+    for coin, subscriptions in by_coin.items():
+        price = await get_price(coin)
+        if price is None:
+            continue
+        for sub_id, chat_id, threshold, last_price in subscriptions:
+            if last_price is None:
+                await set_last_price(sub_id, price)
+                continue
+            change = abs((price - last_price) / last_price * 100)
+            if change >= threshold:
+                await context.bot.send_message(
+                    chat_id=chat_id,
+                    text=(
+                        f"{coin.upper()} price changed {change:.2f}% to ${price:.2f}"
+                    ),
+                )
+                await set_last_price(sub_id, price)
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Start sending price updates every minute."""
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("Subscribe BTC", callback_data="sub:bitcoin")]
+        ]
+    )
     await update.message.reply_text(
-        "Bitcoin price updates will be sent every minute."
+        "Welcome! Use /subscribe <coin> <pct> to subscribe.", reply_markup=keyboard
     )
 
-    # Remove any existing job for this chat
-    if job := context.chat_data.get("price_job"):
-        job.schedule_removal()
 
-    job = context.job_queue.run_repeating(
-        send_price,
-        interval=60,
-        first=0,
-        chat_id=update.effective_chat.id,
+async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "/subscribe <coin> [pct] - subscribe to price alerts\n"
+        "/unsubscribe <coin> - remove subscription\n"
+        "/list - list subscriptions"
     )
-    context.chat_data["price_job"] = job
 
 
-def main() -> None:
+async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text(
+            "Usage: /subscribe <coin> [pct]", quote=True
+        )
+        return
+    coin = context.args[0].lower()
+    try:
+        threshold = float(context.args[1]) if len(context.args) > 1 else DEFAULT_THRESHOLD
+    except ValueError:
+        await update.message.reply_text("Threshold must be a number")
+        return
+
+    await subscribe_coin(update.effective_chat.id, coin, threshold)
+    await update.message.reply_text(
+        f"Subscribed to {coin.upper()} price alerts at ±{threshold}%"
+    )
+
+
+async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Usage: /unsubscribe <coin>")
+        return
+    coin = context.args[0].lower()
+    await unsubscribe_coin(update.effective_chat.id, coin)
+    await update.message.reply_text(f"Unsubscribed from {coin.upper()} alerts")
+
+
+async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    subs = await list_subscriptions(update.effective_chat.id)
+    if not subs:
+        text = "No active subscriptions"
+    else:
+        text = "\n".join(f"{c.upper()} ±{t}%" for c, t in subs)
+    await update.message.reply_text(text)
+
+
+async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    if query.data.startswith("sub:"):
+        coin = query.data.split(":", 1)[1]
+        await subscribe_coin(query.message.chat_id, coin, DEFAULT_THRESHOLD)
+        await query.edit_message_text(
+            f"Subscribed to {coin.upper()} alerts at ±{DEFAULT_THRESHOLD}%"
+        )
+
+
+async def main() -> None:
     load_dotenv()
+    await init_db()
     token = os.getenv("BOT_TOKEN")
     if not token:
         raise RuntimeError("BOT_TOKEN not set")
 
     app = ApplicationBuilder().token(token).build()
+
     app.add_handler(CommandHandler("start", start))
-    app.run_polling()
+    app.add_handler(CommandHandler("help", help_cmd))
+    app.add_handler(CommandHandler("subscribe", subscribe_cmd))
+    app.add_handler(CommandHandler("unsubscribe", unsubscribe_cmd))
+    app.add_handler(CommandHandler("list", list_cmd))
+    app.add_handler(CallbackQueryHandler(button))
+
+    app.job_queue.run_repeating(check_prices, interval=60, first=10)
+
+    await app.initialize()
+    await app.start()
+    await app.updater.start_polling()
+    await app.updater.idle()
 
 
 if __name__ == "__main__":
-    main()
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- implement database-backed subscription model in `run.py`
- add commands `/subscribe`, `/unsubscribe`, `/list`
- poll CoinGecko prices and notify users on threshold breach
- update README with new usage instructions

## Testing
- `python3 -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_6874ee1c7d70832182b9311727464edd