### PR TITLE
Enable regular price checks with APScheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ cp .env.example .env  # edit variables
 python run.py
 ```
 
-The bot uses Telegram's job queue. Ensure the `python-telegram-bot` package is
-installed with the `job-queue` extra as specified in `requirements.txt`.
+The bot uses APScheduler to check prices every 10 seconds. Ensure the
+`python-telegram-bot` package is installed with the `job-queue` extra as
+specified in `requirements.txt`.
 
 Start the bot and use `/start` in a chat with your bot. You can then subscribe
 to coin alerts with:


### PR DESCRIPTION
## Summary
- use APScheduler and Bot parameter for price checking job
- schedule price checks every 10 seconds
- update README with scheduler note

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687503ac6a4883219dd9c88097443290