### PR TITLE
Fix early exit in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,10 +31,6 @@ if ! command -v "$PYTHON" >/dev/null 2>&1; then
         echo "Please install Python 3.8 or newer and re-run this script." >&2
         exit 1
     fi
-
-    echo "Python 3.8+ is required but not found. Please install Python 3.8 or newer." >&2
-    exit 1
-
 fi
 
 # Verify that the Python version meets the minimum requirement


### PR DESCRIPTION
## Summary
- ensure the install script continues after installing Python

## Testing
- `shellcheck install.sh`
- `black --check .`
- `flake8`
- simulated install with missing Python

------
https://chatgpt.com/codex/tasks/task_e_6875085099f0832199690792c478dd5b