### PR TITLE
Implement milestone price alerts

### DIFF
--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from run import milestone_step, milestones_crossed
+
+
+def test_milestone_step():
+    assert milestone_step(2000) == 100.0
+    assert milestone_step(500) == 10.0
+    assert milestone_step(50) == 1.0
+    assert milestone_step(5) == 0.1
+    assert milestone_step(0.5) == 0.01
+    assert milestone_step(0.05) == 0.001
+
+
+def test_milestones_crossed_up():
+    levels = milestones_crossed(95, 105)
+    assert levels == [100]
+
+
+def test_milestones_crossed_down():
+    levels = milestones_crossed(160.1, 159.8)
+    assert levels == [160]


### PR DESCRIPTION
## Summary
- notify when coins cross round price levels
- handle milestone state per chat
- calculate milestone step size based on price
- add unit tests for milestone helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751b42425083219cdf54d1a8716217