### PR TITLE
Add symbol support and unify subscriptions

### DIFF
--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from run import milestone_step, milestones_crossed
+from run import milestone_step, milestones_crossed  # noqa: E402
 
 
 def test_milestone_step():


### PR DESCRIPTION
## Summary
- map coin symbols to IDs and support reverse lookup
- fetch symbols from trending list
- avoid duplicate subscriptions by updating existing entries
- show coin symbols in keyboard and listings
- display full price precision
- adjust tests for flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751e042b6c83218c262d60a73add7c