### PR TITLE
Add subscription management and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env  # edit TELEGRAM_TOKEN and OPENAI_API_KEY
+cp config.json.example config.json  # optional defaults
 python run.py
 ```
+
+Adjust values in `config.json` to change the default alert threshold or interval.
 
 The bot uses APScheduler to check prices every 10 seconds. Ensure the
 `python-telegram-bot` package is installed with the `job-queue` extra as
@@ -31,11 +34,12 @@ Start the bot and use `/start` in a chat with your bot. You can then subscribe
 to coin alerts with:
 
 ```bash
-/subscribe <coin> [percent]
+/subscribe <coin> [percent] [interval]
 ```
 
-List active subscriptions with `/list` and remove them using
-`/unsubscribe <coin>`.
+Intervals can be specified in seconds or with suffixes like `1h`, `15m` or `30s`.
+
+List active subscriptions with `/list` and remove them using `/unsubscribe <coin>`.
 
 ### One-click install
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,4 @@
+{
+  "default_threshold": 0.1,
+  "default_interval": "60s"
+}


### PR DESCRIPTION
## Summary
- add optional `config.json` for default interval/threshold
- implement `parse_duration` for human-readable intervals
- extend `/list` command with inline edit and unsubscribe
- add callback query handler and buttons
- document configuration and interval formats

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752065407083219af67d85aa419e25