### PR TITLE
Add price interval config and inline list controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ cp config.json.example config.json  # optional defaults
 python run.py
 ```
 
-Adjust values in `config.json` to change the default alert threshold or interval.
+Adjust values in `config.json` to change the default alert threshold, the
+default subscription interval or how often the bot queries the API.
 
-The bot uses APScheduler to check prices every 10 seconds. Ensure the
+The bot uses APScheduler to check prices every 60 seconds by default. Ensure the
 `python-telegram-bot` package is installed with the `job-queue` extra as
 specified in `requirements.txt`.
 
@@ -38,6 +39,9 @@ to coin alerts with:
 ```
 
 Intervals can be specified in seconds or with suffixes like `1h`, `15m` or `30s`.
+
+`price_check_interval` in `config.json` controls how often the bot polls the
+API for price updates.
 
 List active subscriptions with `/list` and remove them using `/unsubscribe <coin>`.
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
   "default_threshold": 0.1,
-  "default_interval": "60s"
+  "default_interval": "60s",
+  "price_check_interval": "60s"
 }


### PR DESCRIPTION
## Summary
- make API price polling interval configurable
- show API polling option in docs and example config
- format prices with all decimals
- allow inline edits from /list and menu list
- set default price check interval to 60s

## Testing
- `flake8 run.py tests install.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687523423b7c8321b7b8adf8baef32e6