### PR TITLE
Enhance bot replies with emojis

### DIFF
--- a/run.py
+++ b/run.py
@@ -434,7 +434,7 @@ async def send_rate_limited(bot: Bot, chat_id: int, text: str) -> None:
         wait = 1 - (now - global_messages[0])
         await asyncio.sleep(wait)
 
-    await bot.send_message(chat_id=chat_id, text=text)
+    await bot.send_message(chat_id=chat_id, text=f"{ALERT_EMOJI} {text}")
     user_q.append(time.time())
     global_messages.append(time.time())
 
@@ -488,6 +488,11 @@ async def check_prices(app) -> None:
 SUB_EMOJI = "\U0001fa99"
 LIST_EMOJI = "\U0001f4cb"
 HELP_EMOJI = "\u2753"
+WELCOME_EMOJI = "\U0001f44b"
+INFO_EMOJI = "\u2139\ufe0f"
+SUCCESS_EMOJI = "\u2705"
+ERROR_EMOJI = "\u26a0\ufe0f"
+ALERT_EMOJI = "\U0001f680"
 
 
 def get_keyboard() -> ReplyKeyboardMarkup:
@@ -507,13 +512,14 @@ def get_keyboard() -> ReplyKeyboardMarkup:
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.debug("/start from %s", update.effective_chat.id)
     await update.message.reply_text(
-        "Welcome! Choose an action:", reply_markup=get_keyboard()
+        f"{WELCOME_EMOJI} Welcome! Choose an action:",
+        reply_markup=get_keyboard(),
     )
 
 
 async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(
-        "/subscribe <coin> [pct] [interval] - subscribe to price alerts\n"
+        f"{INFO_EMOJI} /subscribe <coin> [pct] [interval] - subscribe to price alerts\n"
         "/unsubscribe <coin> - remove subscription\n"
         "/list - list subscriptions\n"
         "Intervals can be given like 1h, 15m or 30s",
@@ -524,7 +530,8 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not context.args:
         await update.message.reply_text(
-            "Usage: /subscribe <coin> [pct] [interval]", quote=True
+            f"{ERROR_EMOJI} Usage: /subscribe <coin> [pct] [interval]",
+            quote=True,
         )
         return
     coin = normalize_coin(context.args[0])
@@ -533,7 +540,7 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             float(context.args[1]) if len(context.args) > 1 else DEFAULT_THRESHOLD
         )
     except ValueError:
-        await update.message.reply_text("Threshold must be a number")
+        await update.message.reply_text(f"{ERROR_EMOJI} Threshold must be a number")
         return
 
     try:
@@ -543,7 +550,7 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         interval = parse_duration(interval_str)
     except ValueError:
         await update.message.reply_text(
-            "Interval must be a number or like 1h, 15m, 30s"
+            f"{ERROR_EMOJI} Interval must be a number or like 1h, 15m, 30s"
         )
         return
 
@@ -556,14 +563,17 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         interval,
     )
     await update.message.reply_text(
-        f"Subscribed to {symbol_for(coin)} at ±{threshold}% every {interval}s",
+        (
+            f"{SUCCESS_EMOJI} Subscribed to {symbol_for(coin)} at ±{threshold}% "
+            f"every {interval}s"
+        ),
         reply_markup=get_keyboard(),
     )
 
 
 async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not context.args:
-        await update.message.reply_text("Usage: /unsubscribe <coin>")
+        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /unsubscribe <coin>")
         return
     coin = normalize_coin(context.args[0])
     await unsubscribe_coin(update.effective_chat.id, coin)
@@ -571,10 +581,12 @@ async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     logger.info(
         "chat %s unsubscribes via command from %s", update.effective_chat.id, coin
     )
-    await update.message.reply_text(f"Unsubscribed from {symbol_for(coin)} alerts")
+    await update.message.reply_text(
+        f"{SUCCESS_EMOJI} Unsubscribed from {symbol_for(coin)} alerts"
+    )
 
     await update.message.reply_text(
-        f"Unsubscribed from {symbol_for(coin)} alerts",
+        f"{SUCCESS_EMOJI} Unsubscribed from {symbol_for(coin)} alerts",
         reply_markup=get_keyboard(),
     )
 
@@ -582,7 +594,7 @@ async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     subs = await list_subscriptions(update.effective_chat.id)
     if not subs:
-        await update.message.reply_text("No active subscriptions")
+        await update.message.reply_text(f"{INFO_EMOJI} No active subscriptions")
         return
 
     for _, coin, threshold, interval, last_price, last_ts in subs:
@@ -607,12 +619,12 @@ async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not context.args:
-        await update.message.reply_text("Usage: /info <coin>")
+        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /info <coin>")
         return
     coin = normalize_coin(context.args[0])
     data = await get_coin_info(coin)
     if not data:
-        await update.message.reply_text("Coin not found")
+        await update.message.reply_text(f"{ERROR_EMOJI} Coin not found")
         return
     market = data.get("market_data", {})
     price = market.get("current_price", {}).get("usd")
@@ -621,7 +633,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     sym = data.get("symbol", "").upper()
     COIN_SYMBOLS[coin] = sym
     SYMBOL_TO_COIN[sym.lower()] = coin
-    text = f"{data.get('name')} ({sym})\n"
+    text = f"{INFO_EMOJI} {data.get('name')} ({sym})\n"
     if price is not None:
         text += f"Price: ${price}\n"
     if cap is not None:
@@ -633,7 +645,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not context.args:
-        await update.message.reply_text("Usage: /chart <coin> [days]")
+        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /chart <coin> [days]")
         return
     coin = context.args[0].lower()
     days = 7
@@ -641,11 +653,11 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         try:
             days = int(context.args[1])
         except ValueError:
-            await update.message.reply_text("Days must be a number")
+            await update.message.reply_text(f"{ERROR_EMOJI} Days must be a number")
             return
     data = await get_market_chart(coin, days)
     if not data:
-        await update.message.reply_text("No data available")
+        await update.message.reply_text(f"{ERROR_EMOJI} No data available")
         return
     times, prices = zip(*data)
     plt.figure(figsize=(6, 3))
@@ -662,13 +674,13 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def global_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     data = await get_global_overview()
     if not data:
-        await update.message.reply_text("Failed to fetch data")
+        await update.message.reply_text(f"{ERROR_EMOJI} Failed to fetch data")
         return
     info = data.get("data", {})
     cap = info.get("total_market_cap", {}).get("usd")
     volume = info.get("total_volume", {}).get("usd")
     btc_dom = info.get("market_cap_percentage", {}).get("btc")
-    text = ""
+    text = f"{INFO_EMOJI} "
     if cap is not None:
         text += f"Market Cap: ${cap:,.0f}\n"
     if volume is not None:
@@ -693,26 +705,28 @@ async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await context.bot.send_message(
             chat_id=query.message.chat_id,
             text=(
-                f"Subscribed to {symbol_for(coin)} at ±{DEFAULT_THRESHOLD}% "
-                f"every {DEFAULT_INTERVAL}s"
+                f"{SUCCESS_EMOJI} Subscribed to {symbol_for(coin)} at "
+                f"±{DEFAULT_THRESHOLD}% every {DEFAULT_INTERVAL}s"
             ),
         )
         await query.edit_message_reply_markup(reply_markup=get_keyboard())
     elif query.data.startswith("del:"):
         coin = query.data.split(":", 1)[1]
         await unsubscribe_coin(query.message.chat_id, coin)
-        await query.edit_message_text(f"Unsubscribed from {symbol_for(coin)}")
+        await query.edit_message_text(
+            f"{SUCCESS_EMOJI} Unsubscribed from {symbol_for(coin)}"
+        )
     elif query.data.startswith("edit:"):
         coin = query.data.split(":", 1)[1]
         await context.bot.send_message(
             chat_id=query.message.chat_id,
-            text=f"Use /subscribe {coin} [pct] [interval] to update",
+            text=f"{INFO_EMOJI} Use /subscribe {coin} [pct] [interval] to update",
         )
         await query.edit_message_reply_markup(reply_markup=None)
     elif query.data == "list":
         subs = await list_subscriptions(query.message.chat_id)
         if not subs:
-            text = "No active subscriptions"
+            text = f"{INFO_EMOJI} No active subscriptions"
         else:
             lines = []
             for _, coin, threshold, interval, last_price, last_ts in subs:
@@ -746,8 +760,8 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
             await update.message.reply_text(
                 (
-                    f"Subscribed to {symbol_for(coin)} at ±{DEFAULT_THRESHOLD}% "
-                    f"every {DEFAULT_INTERVAL}s"
+                    f"{SUCCESS_EMOJI} Subscribed to {symbol_for(coin)} at "
+                    f"±{DEFAULT_THRESHOLD}% every {DEFAULT_INTERVAL}s"
                 ),
                 reply_markup=get_keyboard(),
             )
@@ -755,7 +769,7 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         subs = await list_subscriptions(update.effective_chat.id)
 
         if not subs:
-            msg = "No active subscriptions"
+            msg = f"{INFO_EMOJI} No active subscriptions"
         else:
             lines = []
             for _, coin, threshold, interval, last_price, last_ts in subs:
@@ -771,9 +785,12 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(msg, reply_markup=get_keyboard())
     elif text == f"{HELP_EMOJI} Help":
         await update.message.reply_text(
-            "/subscribe <coin> [pct] [seconds] - subscribe to price alerts\n"
-            "/unsubscribe <coin> - remove subscription\n"
-            "/list - list subscriptions",
+            (
+                f"{INFO_EMOJI} /subscribe <coin> [pct] [seconds] - subscribe to "
+                "price alerts\n"
+                "/unsubscribe <coin> - remove subscription\n"
+                "/list - list subscriptions"
+            ),
             reply_markup=get_keyboard(),
         )
 


### PR DESCRIPTION
## Summary
- sprinkle emoji reactions through Telegram bot
- show emoji-enhanced usage and info messages
- prefix alerts with rocket emoji

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687525449fb08321bee7a31ae59191a3