### PR TITLE
Set new default timing values

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,5 @@
 {
   "default_threshold": 0.1,
-  "default_interval": "60s",
-  "price_check_interval": "60s"
+  "default_interval": "5m",
+  "price_check_interval": "30s"
 }

--- a/run.py
+++ b/run.py
@@ -42,8 +42,8 @@ load_dotenv()
 DB_FILE = os.getenv("DB_PATH", "subs.db")
 BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = 0.1
-DEFAULT_INTERVAL = 60
-PRICE_CHECK_INTERVAL = 60
+DEFAULT_INTERVAL = 300
+PRICE_CHECK_INTERVAL = 30
 
 # emojis used for price movements
 UP_ARROW = "\U0001f53a"  # up triangle


### PR DESCRIPTION
## Summary
- use 5 minute default subscription interval and 30 second price checks

## Testing
- `flake8 run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876255476c88321977b0dd9cb1e8aa0