### PR TITLE
Add coinmarketcap option and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ TELEGRAM_TOKEN=
 DB_PATH=./crypto.db
 # Optional CoinGecko API key
 COINGECKO_API_KEY=
+# API provider: coingecko or coinmarketcap
+PRICE_API_PROVIDER=coingecko
+# Optional CoinMarketCap API key
+COINMARKETCAP_API_KEY=

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import pytest  # noqa: E402
+
+from run import global_messages, send_rate_limited, user_messages  # noqa: E402
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+@pytest.mark.asyncio
+async def test_send_rate_limited_format():
+    user_messages.clear()
+    global_messages.clear()
+    bot = DummyBot()
+    await send_rate_limited(bot, 123, "SOL moved -1% to $10", emoji="🔻")
+    assert bot.sent[0][1] == "🔻 SOL moved -1% to $10"

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1,12 +1,17 @@
 import os
 import sys
 
-import pytest
-from aresponses import Response, ResponsesMockServer
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from importlib import reload  # noqa: E402
 
-from run import PRICE_CACHE, get_price  # noqa: E402
+import pytest  # noqa: E402
+from aresponses import Response, ResponsesMockServer  # noqa: E402
+
+import run  # noqa: E402
+
+PRICE_CACHE = run.PRICE_CACHE
+get_price = run.get_price
 
 
 @pytest.mark.asyncio
@@ -25,3 +30,25 @@ async def test_get_price():
         )
         price = await get_price("bitcoin")
         assert price == 5.0
+
+
+@pytest.mark.asyncio
+async def test_get_price_coinmarketcap(monkeypatch):
+    monkeypatch.setenv("PRICE_API_PROVIDER", "coinmarketcap")
+    reload(run)
+    PRICE_CACHE = run.PRICE_CACHE
+    PRICE_CACHE.clear()
+    get_price = run.get_price
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "pro-api.coinmarketcap.com",
+            "/v1/cryptocurrency/quotes/latest",
+            "GET",
+            Response(
+                text='{"data": {"BTC": {"quote": {"USD": {"price": 6.0}}}}}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        price = await get_price("bitcoin")
+        assert price == 6.0


### PR DESCRIPTION
## Summary
- enable switching between CoinGecko and CoinMarketCap APIs
- log outgoing API requests with user info
- prepend emoji to alert messages
- update `.env.example` with new options
- add tests for CoinMarketCap provider and message formatting

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68765aa56d488321aaed135e204de989