### PR TITLE
Fix encoding for CoinGecko search queries

### DIFF
--- a/run.py
+++ b/run.py
@@ -183,7 +183,7 @@ def suggest_coins(name: str, limit: int = 3) -> list[str]:
 async def find_coin(query: str) -> Optional[str]:
     """Return coin id for a symbol or name via the CoinGecko search API."""
     # Query CoinGecko search to expand unknown symbols
-    url = f"{COINGECKO_BASE_URL}/search?query={query}"
+    url = f"{COINGECKO_BASE_URL}/search?query={quote(query, safe='')}"
     try:
         async with aiohttp.ClientSession() as session:
             resp = await api_get(url, session=session, headers=COINGECKO_HEADERS)

--- a/tests/test_find_coin.py
+++ b/tests/test_find_coin.py
@@ -27,3 +27,19 @@ async def test_find_coin():
         result = await find_coin("xrp")
         assert result == "ripple"
         assert run.SYMBOL_TO_COIN["xrp"] == "ripple"
+
+
+@pytest.mark.asyncio
+async def test_find_coin_encodes_query():
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search?query=bitcoin%20cash",
+            "GET",
+            Response(
+                text="{}", status=200, headers={"Content-Type": "application/json"}
+            ),
+            match_querystring=True,
+        )
+        result = await find_coin("bitcoin cash")
+        assert result is None


### PR DESCRIPTION
## Summary
- encode search queries in `find_coin` so spaces don't lead to HTTP 400
- add regression test covering encoded query handling

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f3f390a083218a97207d265ecb22