### PR TITLE
Improve suggest_coins matching

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -27,7 +27,14 @@ def encoded(coin: str) -> str:
 
 
 def suggest_coins(name: str, limit: int = 3) -> list[str]:
-    candidates = list({*config.COINS, *config.TOP_COINS, *config.COIN_SYMBOLS.keys()})
+    candidates = list(
+        {
+            *config.COINS,
+            *config.TOP_COINS,
+            *config.COIN_SYMBOLS.keys(),
+            *config.SYMBOL_TO_COIN.keys(),
+        }
+    )
     matches = get_close_matches(
         name.lower(), [c.lower() for c in candidates], n=limit, cutoff=0.6
     )

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -6,3 +6,12 @@ def test_suggest_coins_basic():
     api.config.TOP_COINS[:] = []
     suggestions = api.suggest_coins("bitcin")
     assert suggestions[0] == "bitcoin"
+
+
+def test_suggest_coins_symbol_lookup():
+    api.config.COINS[:] = ["bitcoin", "ethereum", "dogecoin"]
+    api.config.TOP_COINS[:] = []
+    api.config.COIN_SYMBOLS.update({"bitcoin": "BTC", "ethereum": "ETH"})
+    api.config.SYMBOL_TO_COIN.update({"btc": "bitcoin", "eth": "ethereum"})
+    suggestions = api.suggest_coins("eth")
+    assert suggestions == ["ethereum"]


### PR DESCRIPTION
## Summary
- allow `suggest_coins` to match symbols from `SYMBOL_TO_COIN`
- test symbol matching in `suggest_coins`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780a8d6f70832194003ff319353cb9