### PR TITLE
Improve resolve_coin search strategy

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -342,11 +342,15 @@ async def resolve_coin(query: str, user: Optional[int] = None) -> Optional[str]:
     info = await get_market_info(coin, user=user)
     if info and info.get("current_price") is not None:
         return coin
-    alt = await find_coin(query)
-    if alt:
+
+    for candidate in (coin, query):
+        alt = await find_coin(candidate)
+        if not alt:
+            continue
         info = await get_market_info(alt, user=user)
         if info and info.get("current_price") is not None:
             return alt
+
     return None
 
 

--- a/tests/test_resolve_coin.py
+++ b/tests/test_resolve_coin.py
@@ -32,3 +32,24 @@ async def test_resolve_coin_fallback(monkeypatch):
 
     result = await resolve_coin("xrp")
     assert result == "ripple"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_symbol_search(monkeypatch):
+    async def fake_info(coin, user=None, session=None):
+        if coin == "litecoin-cash":
+            return {"current_price": 1.0}
+        return None
+
+    async def fake_find(query):
+        if query == "litecoin":
+            return None
+        if query == "ltc":
+            return "litecoin-cash"
+        return None
+
+    monkeypatch.setattr(api, "get_market_info", fake_info)
+    monkeypatch.setattr(api, "find_coin", fake_find)
+
+    result = await resolve_coin("ltc")
+    assert result == "litecoin-cash"


### PR DESCRIPTION
## Summary
- search for coins using both the normalized and original query
- test coin resolution when searching by symbol after the normalized lookup fails

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780ade91f4832187c77683e22514fc