### PR TITLE
Improve suggestion fallback for unknown coins

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -26,7 +26,7 @@ def encoded(coin: str) -> str:
     return quote(coin, safe="-")
 
 
-def suggest_coins(name: str, limit: int = 3) -> list[str]:
+async def suggest_coins(name: str, limit: int = 3) -> list[str]:
     candidates = list(
         {
             *config.COINS,
@@ -45,6 +45,11 @@ def suggest_coins(name: str, limit: int = 3) -> list[str]:
         if coin not in seen:
             seen.add(coin)
             result.append(coin)
+
+    if not matches:
+        found = await find_coin(name)
+        if found:
+            return [found]
     return result
 
 

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -286,7 +286,7 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)
@@ -386,7 +386,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)
@@ -424,7 +424,7 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,17 +1,41 @@
+import pytest
+from aresponses import Response, ResponsesMockServer
+
 import pricepulsebot.api as api  # noqa: E402
 
 
-def test_suggest_coins_basic():
+@pytest.mark.asyncio
+async def test_suggest_coins_basic():
     api.config.COINS[:] = ["bitcoin", "ethereum", "dogecoin"]
     api.config.TOP_COINS[:] = []
-    suggestions = api.suggest_coins("bitcin")
+    suggestions = await api.suggest_coins("bitcin")
     assert suggestions[0] == "bitcoin"
 
 
-def test_suggest_coins_symbol_lookup():
+@pytest.mark.asyncio
+async def test_suggest_coins_symbol_lookup():
     api.config.COINS[:] = ["bitcoin", "ethereum", "dogecoin"]
     api.config.TOP_COINS[:] = []
     api.config.COIN_SYMBOLS.update({"bitcoin": "BTC", "ethereum": "ETH"})
     api.config.SYMBOL_TO_COIN.update({"btc": "bitcoin", "eth": "ethereum"})
-    suggestions = api.suggest_coins("eth")
+    suggestions = await api.suggest_coins("eth")
     assert suggestions == ["ethereum"]
+
+
+@pytest.mark.asyncio
+async def test_suggest_coins_api_fallback():
+    api.config.COINS[:] = ["bitcoin"]
+    api.config.TOP_COINS[:] = []
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search",
+            "GET",
+            Response(
+                text='{"coins": [{"id": "ripple", "symbol": "xrp", "name": "XRP"}]}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        suggestions = await api.suggest_coins("xrp")
+        assert suggestions == ["ripple"]


### PR DESCRIPTION
## Summary
- fallback to `find_coin` when `suggest_coins` finds no local matches
- await suggestions in handlers
- test API fallback when suggesting coins

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780d05dbe883218c201f08f81a2f94