### PR TITLE
Optimize trending coin retrieval

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -504,6 +504,10 @@ async def trends_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     if not data:
         await update.message.reply_text(f"{ERROR_EMOJI} Failed to fetch data")
         return
+    data = sorted(
+        data,
+        key=lambda x: (x.get("change_24h") is None, -(x.get("change_24h") or 0)),
+    )
     lines = []
     for item in data:
         coin_id = item.get("id")

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -17,8 +17,10 @@ async def test_fetch_trending_coins_cached(tmp_path, monkeypatch):
             "GET",
             Response(
                 text=(
-                    '{"coins": [{"item": {"id": "solana", "symbol": "sol", '
-                    '"name": "Solana"}}]}'
+                    '{"coins": ['
+                    '{"item": {"id": "solana", "symbol": "sol", "name": "Solana"}},'
+                    '{"item": {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"}}'
+                    "]}"
                 ),
                 status=200,
                 headers={"Content-Type": "application/json"},
@@ -31,7 +33,9 @@ async def test_fetch_trending_coins_cached(tmp_path, monkeypatch):
             Response(
                 text=(
                     '[{"id": "solana", "current_price": 1.0, '
-                    '"price_change_percentage_24h": 2.0}]'
+                    '"price_change_percentage_24h": 2.0},'
+                    '{"id": "bitcoin", "current_price": 2.0, '
+                    '"price_change_percentage_24h": 1.0}]'
                 ),
                 status=200,
                 headers={"Content-Type": "application/json"},
@@ -49,4 +53,4 @@ async def test_fetch_trending_coins_cached(tmp_path, monkeypatch):
     config.COINS = []
     again = await api.fetch_trending_coins()
     assert again == cached
-    assert config.COINS == ["solana"]
+    assert config.COINS == ["solana", "bitcoin"]


### PR DESCRIPTION
## Summary
- fetch market data for trending coins in one request
- order trending list by 24h change
- display `/trends` output sorted
- adjust tests for new behaviour

## Testing
- `isort . && black . && flake8 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782810c9d88321b0ec2cddfe862448