### PR TITLE
Add runtime settings and milestone toggle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
 - `/trends` – show trending coins
 - `/global` – show global market stats
+- `/milestones [on|off]` – toggle milestone notifications
+- `/settings [key value]` – show or change default settings
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.
 

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -36,6 +36,8 @@ async def main() -> None:
     app.add_handler(CommandHandler("trends", handlers.trends_cmd))
     app.add_handler(CommandHandler("global", handlers.global_cmd))
     app.add_handler(CommandHandler("valuearea", handlers.valuearea_cmd))
+    app.add_handler(CommandHandler("milestones", handlers.milestones_cmd))
+    app.add_handler(CommandHandler("settings", handlers.settings_cmd))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.menu))
     app.add_handler(CallbackQueryHandler(handlers.button))
 
@@ -64,6 +66,8 @@ async def main() -> None:
             BotCommand("trends", "Trending coins"),
             BotCommand("global", "Global market"),
             BotCommand("valuearea", "Volume profile"),
+            BotCommand("milestones", "Toggle milestone alerts"),
+            BotCommand("settings", "Show or change defaults"),
         ]
     )
     await app.start()

--- a/tests/test_milestones_cmd.py
+++ b/tests/test_milestones_cmd.py
@@ -1,0 +1,34 @@
+import pytest
+
+import pricepulsebot.config as config
+import pricepulsebot.handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+
+
+@pytest.mark.asyncio
+async def test_milestones_cmd_toggle():
+    update = DummyUpdate()
+    ctx = DummyContext(["on"])
+    prev = config.ENABLE_MILESTONE_ALERTS
+    config.ENABLE_MILESTONE_ALERTS = False
+    await handlers.milestones_cmd(update, ctx)
+    assert config.ENABLE_MILESTONE_ALERTS is True
+    config.ENABLE_MILESTONE_ALERTS = prev

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -1,0 +1,63 @@
+import pytest
+
+import pricepulsebot.config as config
+import pricepulsebot.handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+
+
+@pytest.mark.asyncio
+async def test_settings_update_threshold():
+    update = DummyUpdate()
+    ctx = DummyContext(["threshold", "2.0"])
+    prev = config.DEFAULT_THRESHOLD
+    await handlers.settings_cmd(update, ctx)
+    assert config.DEFAULT_THRESHOLD == 2.0
+    config.DEFAULT_THRESHOLD = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_update_interval():
+    update = DummyUpdate()
+    ctx = DummyContext(["interval", "10m"])
+    prev = config.DEFAULT_INTERVAL
+    await handlers.settings_cmd(update, ctx)
+    assert config.DEFAULT_INTERVAL == config.parse_duration("10m")
+    config.DEFAULT_INTERVAL = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_update_milestones():
+    update = DummyUpdate()
+    ctx = DummyContext(["milestones", "off"])
+    prev = config.ENABLE_MILESTONE_ALERTS
+    await handlers.settings_cmd(update, ctx)
+    assert config.ENABLE_MILESTONE_ALERTS is False
+    config.ENABLE_MILESTONE_ALERTS = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_pricecheck_readonly():
+    update = DummyUpdate()
+    ctx = DummyContext(["pricecheck", "30s"])
+    prev = config.PRICE_CHECK_INTERVAL
+    await handlers.settings_cmd(update, ctx)
+    assert config.PRICE_CHECK_INTERVAL == prev
+    assert update.message.texts


### PR DESCRIPTION
## Summary
- implement `/milestones` command to toggle milestone alerts
- implement `/settings` command to adjust default threshold, interval and milestone alerts while price check interval remains read-only
- register new commands in the bot and document them
- test the new handlers

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687920c835848321a4afae4460a4cba6