### PR TITLE
Add configurable vs currency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ DEFAULT_INTERVAL=5m
 PRICE_CHECK_INTERVAL=30s
 # Enable price milestone alerts (true/false)
 ENABLE_MILESTONE_ALERTS=true
+# Default currency used when fetching prices
+DEFAULT_VS_CURRENCY=usd

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # DEFAULT_THRESHOLD and DEFAULT_INTERVAL control new subscriptions
 # PRICE_CHECK_INTERVAL sets how often prices are fetched
 # ENABLE_MILESTONE_ALERTS toggles milestone notifications
+# DEFAULT_VS_CURRENCY sets the reference currency used for prices
 python run.py
 ```
 
@@ -49,6 +50,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `DEFAULT_INTERVAL` – subscription interval when none is given
 - `PRICE_CHECK_INTERVAL` – how often prices are checked
 - `ENABLE_MILESTONE_ALERTS` – send messages for price milestones
+- `DEFAULT_VS_CURRENCY` – default currency used for API requests
 
 ### Commands
 
@@ -61,7 +63,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/global` – show global market stats
 - `/status` – display API status overview
 - `/milestones [on|off]` – toggle milestone notifications (no args switch)
-- `/settings [key value]` – show or change default settings
+- `/settings [key value]` – show or change default settings (threshold,
+  interval, milestones, currency)
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.
 

--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -186,7 +186,7 @@ async def get_price(
 
     url = (
         f"{config.COINGECKO_BASE_URL}/simple/price"
-        f"?ids={encoded(coin)}&vs_currencies=usd"
+        f"?ids={encoded(coin)}&vs_currencies={config.VS_CURRENCY}"
     )
     headers = config.COINGECKO_HEADERS
     key = coin
@@ -201,7 +201,7 @@ async def get_price(
                 return None
             if resp.status == 200:
                 data = await resp.json()
-                price = data.get(key, {}).get("usd")
+                price = data.get(key, {}).get(config.VS_CURRENCY)
                 if price is not None:
                     price = float(price)
                     PRICE_CACHE[coin] = (price, time.time())
@@ -237,7 +237,7 @@ async def get_prices(
         Mapping of coin ID to its current price.
     """
     ids = ",".join(encoded(c) for c in coins)
-    url = f"{config.COINGECKO_BASE_URL}/simple/price?ids={ids}&vs_currencies=usd"
+    url = f"{config.COINGECKO_BASE_URL}/simple/price?ids={ids}&vs_currencies={config.VS_CURRENCY}"
     retries = 3
     owns_session = session is None
     if owns_session:
@@ -254,7 +254,7 @@ async def get_prices(
                 now = time.time()
                 result = {}
                 for coin in coins:
-                    price = data.get(coin, {}).get("usd")
+                    price = data.get(coin, {}).get(config.VS_CURRENCY)
                     if price is not None:
                         price = float(price)
                         PRICE_CACHE[coin] = (price, now)
@@ -293,7 +293,7 @@ async def get_markets(
     ids = ",".join(encoded(c) for c in coins)
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/markets"
-        f"?vs_currency=usd&ids={ids}&price_change_percentage=24h"
+        f"?vs_currency={config.VS_CURRENCY}&ids={ids}&price_change_percentage=24h"
     )
     retries = 3
     owns_session = session is None
@@ -435,7 +435,7 @@ async def get_market_info(
     """Return market data for ``coin`` such as price and 24h change."""
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/markets"
-        f"?vs_currency=usd&ids={encoded(coin)}&price_change_percentage=24h"
+        f"?vs_currency={config.VS_CURRENCY}&ids={encoded(coin)}&price_change_percentage=24h"
     )
     headers = config.COINGECKO_HEADERS
     owns_session = session is None
@@ -487,7 +487,7 @@ async def get_market_chart(
     start_ts = end_ts - days * 86400
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/{encoded(coin)}/market_chart/range"
-        f"?vs_currency=usd&from={start_ts}&to={end_ts}"
+        f"?vs_currency={config.VS_CURRENCY}&from={start_ts}&to={end_ts}"
     )
     headers = config.COINGECKO_HEADERS
     owns_session = session is None
@@ -657,7 +657,7 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
             if ids:
                 markets_url = (
                     f"{config.COINGECKO_BASE_URL}/coins/markets"
-                    f"?vs_currency=usd&ids={','.join(ids)}&price_change_percentage=24h"
+                    f"?vs_currency={config.VS_CURRENCY}&ids={','.join(ids)}&price_change_percentage=24h"
                 )
                 market_resp = await api_get(
                     markets_url, session=session, headers=config.COINGECKO_HEADERS
@@ -708,7 +708,7 @@ async def fetch_top_coins() -> None:
     """Update :data:`config.TOP_COINS` with high market cap coins."""
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/markets"
-        "?vs_currency=usd&order=market_cap_desc&per_page=50&page=1"
+        f"?vs_currency={config.VS_CURRENCY}&order=market_cap_desc&per_page=50&page=1"
     )
     try:
         async with aiohttp.ClientSession() as session:

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -43,6 +43,7 @@ DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
 ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"
+VS_CURRENCY = os.getenv("DEFAULT_VS_CURRENCY", "usd").lower()
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = (

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -130,9 +130,9 @@ def trend_emojis(change: float) -> str:
 
 
 def usd_value(value: Optional[object]) -> Optional[float]:
-    """Return the USD float when given either a number or a dict."""
+    """Return the configured currency float when given either a number or a dict."""
     if isinstance(value, dict):
-        return value.get("usd")
+        return value.get(config.VS_CURRENCY)
     if isinstance(value, (int, float)):
         return float(value)
     return None
@@ -595,8 +595,8 @@ async def global_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await update.message.reply_text(f"{ERROR_EMOJI} Failed to fetch data")
         return
     info = data.get("data", {})
-    cap = info.get("total_market_cap", {}).get("usd")
-    volume = info.get("total_volume", {}).get("usd")
+    cap = info.get("total_market_cap", {}).get(config.VS_CURRENCY)
+    volume = info.get("total_volume", {}).get(config.VS_CURRENCY)
     btc_dom = info.get("market_cap_percentage", {}).get("btc")
     cap_change = info.get("market_cap_change_percentage_24h_usd")
     active = info.get("active_cryptocurrencies")
@@ -709,13 +709,14 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             f"- threshold: ±{config.DEFAULT_THRESHOLD}%\n"
             f"- interval: {config.format_interval(config.DEFAULT_INTERVAL)}\n"
             f"- pricecheck: {config.format_interval(config.PRICE_CHECK_INTERVAL)}\n"
-            f"- milestones: {'on' if config.ENABLE_MILESTONE_ALERTS else 'off'}"
+            f"- milestones: {'on' if config.ENABLE_MILESTONE_ALERTS else 'off'}\n"
+            f"- currency: {config.VS_CURRENCY}"
         )
         await update.message.reply_text(text)
         return
     if len(context.args) < 2:
         await update.message.reply_text(
-            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones> <value>"
+            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency> <value>"
         )
         return
     key = context.args[0].lower()
@@ -751,6 +752,11 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         config.ENABLE_MILESTONE_ALERTS = val == "on"
         state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
         await update.message.reply_text(f"{SUCCESS_EMOJI} Milestone alerts {state}")
+    elif key == "currency":
+        config.VS_CURRENCY = value.lower()
+        await update.message.reply_text(
+            f"{SUCCESS_EMOJI} Default currency set to {config.VS_CURRENCY}"
+        )
     elif key == "pricecheck":
         await update.message.reply_text(
             f"{ERROR_EMOJI} PRICE_CHECK_INTERVAL cannot be changed"

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -61,3 +61,13 @@ async def test_settings_pricecheck_readonly():
     await handlers.settings_cmd(update, ctx)
     assert config.PRICE_CHECK_INTERVAL == prev
     assert update.message.texts
+
+
+@pytest.mark.asyncio
+async def test_settings_update_currency():
+    update = DummyUpdate()
+    ctx = DummyContext(["currency", "eur"])
+    prev = config.VS_CURRENCY
+    await handlers.settings_cmd(update, ctx)
+    assert config.VS_CURRENCY == "eur"
+    config.VS_CURRENCY = prev


### PR DESCRIPTION
## Summary
- allow configuring the default comparison currency
- expose `VS_CURRENCY` in `config`
- show and modify the setting in `/settings`
- use the constant in all API calls
- document new setting and add tests

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pricepulsebot')*

------
https://chatgpt.com/codex/tasks/task_e_68795afced448321b9a559ee32d707a5