### PR TITLE
Sync settings command and menu

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -508,6 +508,7 @@ def get_settings_menu() -> ReplyKeyboardMarkup:
                 f"milestones: {'on' if config.ENABLE_MILESTONE_ALERTS else 'off'}"
             )
         ],
+        [KeyboardButton(f"volume: {'on' if config.ENABLE_VOLUME_ALERTS else 'off'}")],
         [
             KeyboardButton(
                 f"liquidations: {'on' if config.ENABLE_LIQUIDATION_ALERTS else 'off'}"
@@ -958,7 +959,7 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     """View or modify default alert settings."""
     if not context.args:
         text = f"{INFO_EMOJI} Current settings:"
-        await update.message.reply_text(text, reply_markup=get_settings_keyboard())
+        await update.message.reply_text(text, reply_markup=get_settings_menu())
         return
     if len(context.args) < 2:
         usage = (
@@ -1206,6 +1207,13 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
         await update.message.reply_text(
             f"{SUCCESS_EMOJI} Milestone alerts {state}",
+            reply_markup=get_settings_menu(),
+        )
+    elif text.startswith("volume"):
+        config.ENABLE_VOLUME_ALERTS = not config.ENABLE_VOLUME_ALERTS
+        state = "enabled" if config.ENABLE_VOLUME_ALERTS else "disabled"
+        await update.message.reply_text(
+            f"{SUCCESS_EMOJI} Volume alerts {state}",
             reply_markup=get_settings_menu(),
         )
     elif text.startswith("liquidations"):

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -2,7 +2,7 @@ import pytest
 
 import pricepulsebot.config as config
 import pricepulsebot.handlers as handlers
-from pricepulsebot.handlers import InlineKeyboardMarkup
+from pricepulsebot.handlers import InlineKeyboardMarkup, ReplyKeyboardMarkup
 
 
 class DummyMessage:
@@ -128,7 +128,9 @@ async def test_settings_keyboard():
     update = DummyUpdate()
     ctx = DummyContext([])
     await handlers.settings_cmd(update, ctx)
-    assert update.message.markups and update.message.markups[0] is not None
+    assert update.message.markups and isinstance(
+        update.message.markups[0], ReplyKeyboardMarkup
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -54,3 +54,24 @@ async def test_settings_menu_toggle_and_back():
     assert kb.keyboard[1][1].text == SETTINGS_EMOJI
 
     config.DEFAULT_THRESHOLD = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_menu_volume_toggle():
+    prev = config.ENABLE_VOLUME_ALERTS
+    update = DummyUpdate(SETTINGS_EMOJI)
+    ctx = DummyContext()
+    await handlers.menu(update, ctx)
+    assert any(
+        "volume" in btn.text
+        for row in update.message.markups[-1].keyboard
+        for btn in row
+    )
+
+    update.message.text = (
+        f"volume: {'on' if not config.ENABLE_VOLUME_ALERTS else 'off'}"
+    )
+    await handlers.menu(update, ctx)
+    assert config.ENABLE_VOLUME_ALERTS != prev
+    assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
+    config.ENABLE_VOLUME_ALERTS = prev


### PR DESCRIPTION
## Summary
- include volume toggle in reply keyboard menu
- show reply keyboard in `/settings` command
- test volume toggle and keyboard type

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879834ca8808321b0e6de7929e73a89