### PR TITLE
Fix price formatting precision

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -134,7 +134,10 @@ def milestone_step(price: float) -> float:
 
 def format_price(value: float) -> str:
     """Format ``value`` as a price string."""
-    text = format(Decimal(str(value)), "f")
+    # limit precision to avoid floating point artifacts like
+    # ``0.00013000000000000002``
+    d = Decimal(value).quantize(Decimal("1e-8"))
+    text = format(d.normalize(), "f")
     if "." in text:
         frac = text.split(".")[1]
         if len(frac) == 1:

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -31,6 +31,11 @@ def test_format_price_small_value():
     assert format_price(3.7e-05) == "0.000037"
 
 
+def test_format_price_removes_artifacts():
+    value = 0.00013000000000000002
+    assert format_price(value) == "0.00013"
+
+
 def test_milestone_message_format():
     level = 0.6
     price = 0.65


### PR DESCRIPTION
## Summary
- format prices with Decimal quantization to avoid floating point artifacts
- test that price formatting trims unwanted digits

## Testing
- `flake8`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a308a712c8321b66c0cd9657ea0fa