### PR TITLE
Ensure cache refresh matches price interval

### DIFF
--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -59,7 +59,12 @@ async def main() -> None:
         scheduler.add_job(
             liquidations.check_liquidations, "interval", minutes=1, args=(app,)
         )
-    scheduler.add_job(handlers.refresh_cache, "interval", minutes=5, args=(app,))
+    scheduler.add_job(
+        handlers.refresh_cache,
+        "interval",
+        seconds=config.PRICE_CHECK_INTERVAL,
+        args=(app,),
+    )
     scheduler.add_job(api.fetch_trending_coins, "interval", minutes=10)
     scheduler.add_job(api.fetch_top_coins, "interval", minutes=10)
     scheduler.start()


### PR DESCRIPTION
## Summary
- schedule `refresh_cache` with `PRICE_CHECK_INTERVAL`

## Testing
- `pytest -q`
- `shellcheck install.sh`


------
https://chatgpt.com/codex/tasks/task_e_687a493428988321adb841afa19d122c