### PR TITLE
Improve chart timeframe formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/clear` – remove all subscriptions
 - `/list` – list active subscriptions
 - `/info <coin>` – show current coin data
-- `/chart <coin> [days]` – plot price history (alias `/charts`)
+ - `/chart <coin> [period]` – plot price history for a timeframe (alias `/charts`)
 - `/news [coin]` – show latest news (uses subscriptions when omitted)
 - `/trends` – show trending coins
 - `/top` – show top market cap coins
@@ -76,6 +76,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
   interval, milestones, volume, currency)
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.
+Periods default to days but accept suffixes like `h` or `m`.
 
 ### One‑click install
 

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -26,6 +26,18 @@ def parse_duration(value: str) -> int:
     return int(num) * factor
 
 
+def parse_timeframe(value: str) -> int:
+    """Return seconds for a timeframe string.
+
+    Pure numbers are interpreted as days while values with a trailing unit are
+    delegated to :func:`parse_duration` to support hours or minutes.
+    """
+
+    if value.isdigit():
+        return int(value) * 86400
+    return parse_duration(value)
+
+
 def format_interval(seconds: int) -> str:
     """Return a short string representation for a duration in seconds."""
     if seconds % 86400 == 0:

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -806,7 +806,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send a price chart image for a coin."""
     if not context.args:
-        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /chart <coin> [days]")
+        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /chart <coin> [period]")
         return
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
@@ -818,13 +818,16 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             msg += f". Did you mean {syms}?"
         await update.message.reply_text(msg)
         return
-    days = 7
+    seconds = 86400
     if len(context.args) > 1:
         try:
-            days = int(context.args[1])
+            seconds = config.parse_timeframe(context.args[1])
         except ValueError:
-            await update.message.reply_text(f"{ERROR_EMOJI} Days must be a number")
+            await update.message.reply_text(
+                f"{ERROR_EMOJI} Period must be a number or like 1h, 30m"
+            )
             return
+    days = seconds / 86400
     cached = await db.get_coin_data(coin)
     if days == 7 and cached and cached.get("chart_7d") is not None:
         data = [(p[0], p[1]) for p in cached["chart_7d"]]
@@ -845,9 +848,13 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     plt.plot(times, prices)
     ax = plt.gca()
     ax.xaxis.set_major_locator(mdates.AutoDateLocator())
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
-    plt.xlabel("Date")
-    plt.title(f"{coin.upper()} last {days} days")
+    if seconds < 86400:
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+        plt.xlabel("Time")
+    else:
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+        plt.xlabel("Date")
+    plt.title(f"{coin.upper()} last {config.format_interval(seconds)}")
     plt.tight_layout()
     buf = BytesIO()
     plt.savefig(buf, format="png")

--- a/tests/test_timeframe.py
+++ b/tests/test_timeframe.py
@@ -1,0 +1,20 @@
+import pytest
+
+import pricepulsebot.config as config
+
+
+def test_parse_timeframe_days():
+    assert config.parse_timeframe("3") == 3 * 86400
+
+
+def test_parse_timeframe_hours():
+    assert config.parse_timeframe("2h") == 2 * 3600
+
+
+def test_parse_timeframe_minutes():
+    assert config.parse_timeframe("30m") == 30 * 60
+
+
+def test_parse_timeframe_invalid():
+    with pytest.raises(ValueError):
+        config.parse_timeframe("xh")


### PR DESCRIPTION
## Summary
- show hour ticks on `/chart` when period < 1 day
- add minutes test for timeframe parsing
- document chart period units in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a71c77cec83218c3407119764be1f