### PR TITLE
Add coin inline menu and auto info

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -8,8 +8,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 @pytest.mark.asyncio

--- a/tests/test_coin_data.py
+++ b/tests/test_coin_data.py
@@ -15,8 +15,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 class DummyApp:

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -13,8 +13,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 class DummyApp:

--- a/tests/test_milestone_toggle.py
+++ b/tests/test_milestone_toggle.py
@@ -14,8 +14,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 class DummyApp:

--- a/tests/test_target_price.py
+++ b/tests/test_target_price.py
@@ -14,8 +14,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 class DummyApp:
@@ -44,4 +44,4 @@ async def test_absolute_price_alert(tmp_path, monkeypatch):
     MILESTONE_CACHE.clear()
     await handlers.check_prices(app)
     MILESTONE_CACHE.clear()
-    assert any("reached" in msg for _, msg in bot.sent)
+    assert any("reached" in msg for _, msg, _ in bot.sent)

--- a/tests/test_volume_alerts.py
+++ b/tests/test_volume_alerts.py
@@ -14,8 +14,8 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, chat_id, text):
-        self.sent.append((chat_id, text))
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text, kwargs.get("reply_markup")))
 
 
 class DummyApp:
@@ -52,7 +52,7 @@ async def test_volume_spike_alert(tmp_path, monkeypatch):
     MILESTONE_CACHE.clear()
     await handlers.check_prices(app)
     MILESTONE_CACHE.clear()
-    assert any("volume" in msg for _, msg in bot.sent)
+    assert any("volume" in msg for _, msg, _ in bot.sent)
 
 
 @pytest.mark.asyncio
@@ -84,7 +84,7 @@ async def test_volume_drop_alert(tmp_path, monkeypatch):
     MILESTONE_CACHE.clear()
     await handlers.check_prices(app)
     MILESTONE_CACHE.clear()
-    assert any("volume" in msg for _, msg in bot.sent)
+    assert any("volume" in msg for _, msg, _ in bot.sent)
 
 
 @pytest.mark.asyncio
@@ -119,4 +119,4 @@ async def test_volume_alerts_disabled(tmp_path, monkeypatch):
     await handlers.check_prices(app)
     MILESTONE_CACHE.clear()
     config.ENABLE_VOLUME_ALERTS = prev
-    assert not any("volume" in msg for _, msg in bot.sent)
+    assert not any("volume" in msg for _, msg, _ in bot.sent)


### PR DESCRIPTION
## Summary
- attach inline menu with chart, info and news for coin messages
- run info after subscribing
- handle new inline buttons in callback handler
- adjust tests for new reply_markup usage

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4152067c8321973b3d9dfa2c30db